### PR TITLE
fix(ffmpeg): enhance text-to-speech functionality

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -47,9 +47,10 @@ def text_to_speech():
 
     # Generate the audio file in the specified format with speed adjustment
     output_file_path = generate_speech(text, voice, response_format, speed)
+    output_file_ext = os.path.splitext(output_file_path)[1]
 
     # Return the file with the correct MIME type
-    return send_file(output_file_path, mimetype=mime_type, as_attachment=True, download_name=f"speech.{response_format}")
+    return send_file(output_file_path, mimetype=mime_type, as_attachment=True, download_name=f"speech{output_file_ext}")
 
 @app.route('/v1/models', methods=['GET', 'POST'])
 @app.route('/models', methods=['GET', 'POST'])

--- a/app/tts_handler.py
+++ b/app/tts_handler.py
@@ -68,7 +68,9 @@ async def _generate_audio(text, voice, response_format, speed):
             "opus": "libopus",
             "flac": "flac"
         }.get(response_format, "aac"),  # Default to AAC if unknown
-        "-b:a", "192k" if response_format != "wav" else None,  # Bitrate not needed for WAV
+    ] + ([
+        "-b:a", "192k"  # Bitrate not needed for WAV
+    ] if response_format != "wav" else []) + [
         "-f", {
             "aac": "mp4",  # AAC in MP4 container
             "mp3": "mp3",


### PR DESCRIPTION
- Modify download name to include the correct file extension
- Adjust bitrate settings for different response formats

# explain

1. The file extension should be inferred from the output filename rather than being specified by the user; otherwise, it may cause confusion when a non-mp3 extension is specified without ffmpeg.
2. The ffmpeg command should leave the bitrate setting empty rather than setting it to None, as the latter could lead to a non-zero exit.