### PR TITLE
Introduce HOST variable for server configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 API_KEY=your_api_key_here
+HOST=0.0.0.0
 PORT=5050
 
 DEFAULT_VOICE=en-US-AvaNeural

--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@
 
 DEFAULT_CONFIGS = {
     # Server settings
+    "HOST": '0.0.0.0',
     "PORT": 5050,
     "API_KEY": 'your_api_key_here',  # Fallback API key
 

--- a/app/server.py
+++ b/app/server.py
@@ -17,6 +17,7 @@ app = Flask(__name__)
 load_dotenv()
 
 API_KEY = os.getenv('API_KEY', DEFAULT_CONFIGS["API_KEY"])
+HOST = os.getenv('HOST', DEFAULT_CONFIGS["HOST"])
 PORT = int(os.getenv('PORT', str(DEFAULT_CONFIGS["PORT"])))
 
 DEFAULT_VOICE = os.getenv('DEFAULT_VOICE', DEFAULT_CONFIGS["DEFAULT_VOICE"])
@@ -258,5 +259,5 @@ print(f" * TTS Endpoint: http://localhost:{PORT}/v1/audio/speech")
 print(f" ")
 
 if __name__ == '__main__':
-    http_server = WSGIServer(('0.0.0.0', PORT), app)
+    http_server = WSGIServer((HOST, PORT), app)
     http_server.serve_forever()


### PR DESCRIPTION
This change will allow any user to setup openai-edge-tts to listen to localhost by setting HOST to 127.0.0.1 for example. This is useful for non-docker installs.

By default, it still listens to 0.0.0.0